### PR TITLE
Rules revised

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ The objective for this group is to set out the rules of engagement for CHERI all
 Besides setting out the rules, this working group should also make sure that each repository has someone who takes responsibility for it and it has a purpose.
 To contact this working group, please use [this email](mailto:wg-repo-mgmt@cheri-alliance.org).
 
+## Notes for this repository
+
+This repository has a protected branch and uses rebasing for contributions.
+People with write access should be part of the repository management working group.

--- a/repository_creation_rules.md
+++ b/repository_creation_rules.md
@@ -9,7 +9,7 @@ If a working group wants a repository they can create one as long as there is no
 If there is a naming clash, this should be referred to the repository management working group.
 If a repository applies to multiple working groups, they can decide this together.
 If there is a disagreement between working groups, this should be referred to the repository management working group.
-If someone wants to create a repository without an existing working group, please get in contact with the repository management working group.
+If someone wants to create a repository without an existing working group, please contact the repository management working group.
 
 When creating a new repository that is similar to one that already exists, this should be discussed with the existing working group or person responsible for the already existing repository.
 On a general note, we prefer maintaining branches on an existing repository unless there is a good reason not to.
@@ -17,14 +17,14 @@ On a general note, we prefer maintaining branches on an existing repository unle
 In all cases, when a repository is created, it should have an initial responsible working group or person.
 For public repositories please open an issue on this repository.
 In this issue it should also be clear if this is a fork of an existing repository and the expected lifetime of the project.
-Short-term projects can be those where it's a staging ground for upstreaming, while longer-term projects can be those where the CHERI alliance needs to provide longer-term support.
-For private repositories please send an email to this working group.
+Short-term projects can be those where it's a staging ground for upstreaming, while longer-term projects can be those where the CHERI alliance sees a need to support the community or fill a gap.
+For private repositories please send an email to the repository management working group.
 
 ## License
 
 When creating a repository these are usually based on existing projects with existing licenses.
-Projects with well-known open-source licenses should be fine.
-If you have any doubt, please contact this working group.
+Projects with well-known open-source licenses like those defined by the [OSI](https://opensource.org/licenses?categories=popular-strong-community) should be fine.
+If you have any doubt, please contact the repository management working group.
 
 If this is a completely new project, we prefer [permissive licenses](https://en.wikipedia.org/wiki/Permissive_software_license).
 
@@ -37,7 +37,3 @@ These are not mandates but are some best practices any active repository should 
 - Decide and clearly state whether you prefer merging or rebasing flow.
 - Define how to manage those with write access.
 - Have a meaningful one-line description in the "About" section.
-
-## Notes for this repository
-
-This repository should use rebasing for contributions.


### PR DESCRIPTION
Replace some of "this working group" with "repository management working group". Moved the rules about this repository to the README in preparation of the rules being moved out of the repo. Add link to the OSI popular and strong community licenses for existing projects.